### PR TITLE
bugfix/background-light

### DIFF
--- a/src/sass/utils/_variables.scss
+++ b/src/sass/utils/_variables.scss
@@ -10,7 +10,7 @@ $button-hover: #876655;
 $button-active: #674d40;
 
 $background-dark: #fef3e4;
-$background-light: #e5e5e5;
+$background-light: #ffffff;
 $background-mob-menu: rgba(254, 243, 228, 0.9);
 $background-registration: #fffff9;
 


### PR DESCRIPTION
Пардон, с утра второпях неверно определил цвет "светлого" фона. На макете до него почему-то достучаться трудно, а Фигма выдаёт свой родной `#e5e5e5`. На самом деле, там банальный белый `#ffffff`.