### PR TITLE
Feature/mixin bgimg

### DIFF
--- a/src/sass/utils/_mixin.scss
+++ b/src/sass/utils/_mixin.scss
@@ -1,9 +1,33 @@
 @mixin trans($properties...) {
-  @if length($properties) <= 1 {
-    transition: $properties $trans-dur $trans-func;
-  } @else {
-    transition-property: $properties;
-    transition-duration: $trans-dur;
-    transition-timing-function: $trans-func;
-  }
+    @if length($properties) <=1 {
+        transition: $properties $trans-dur $trans-func;
+    }
+    @else {
+        transition-property: $properties;
+        transition-duration: $trans-dur;
+        transition-timing-function: $trans-func;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+////////////////////////  Service mixin for bgimg  ////////////////////////
+///////////////////////////////////////////////////////////////////////////
+@mixin bgimg_simple($prefix, $suffix, $mobile, $tablet, $desktop) {
+    background-image: url('#{$prefix}#{$mobile}#{$suffix}');
+    @if ($tablet != $mobile) {
+        @media screen and (min-width: 768px) {
+            background-image: url('#{$prefix}#{$tablet}#{$suffix}');
+        }
+    }
+    @media screen and (min-width: 1280px) {
+        background-image: url('#{$prefix}#{$desktop}#{$suffix}');
+    }
+}
+///////////////////////////////////////////////////////////////////////////
+
+@mixin bgimg($prefix, $extension: 'png', $mobile: 'mobile', $tablet: 'tablet', $desktop: 'desktop', $double-res: '@2x') {
+    @include bgimg_simple($prefix, '.' + $extension, '_' + $mobile, '_' + $tablet, '_' + $desktop);
+    @media screen and (min-resolution: 2) {
+        @include bgimg_simple($prefix, $double-res + '.' + $extension, '_' + $mobile, '_' + $tablet, '_' + $desktop);
+    }
 }

--- a/src/sass/utils/_mixin.scss
+++ b/src/sass/utils/_mixin.scss
@@ -27,7 +27,7 @@
 
 @mixin bgimg($prefix, $extension: 'png', $mobile: 'mobile', $tablet: 'tablet', $desktop: 'desktop', $double-res: '@2x') {
     @include bgimg_simple($prefix, '.' + $extension, '_' + $mobile, '_' + $tablet, '_' + $desktop);
-    @media screen and (min-resolution: 2) {
+    @media screen and (min-device-pixel-ratio: 2), (-webkit-min-device-pixel-ratio: 2), (-moz-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx) {
         @include bgimg_simple($prefix, $double-res + '.' + $extension, '_' + $mobile, '_' + $tablet, '_' + $desktop);
     }
 }


### PR DESCRIPTION
Целую пачку фоновых изображений, например,
> ../images/hero/hero_mobile.png
> ../images/hero/hero_mobile@2x.png
> ../images/hero/hero_tablet.png
> ../images/hero/hero_tablet@2x.png
> ../images/hero/hero_desktop.png
> ../images/hero/hero_desktop@2x.png

теперь можно подключить всего одной строкой:
`@include bgimg('../images/hero/hero');`

Почему два раза "hero"? Потому что пишется имя файла вплоть до нижнего подчёркивания.

В нестандартных ситуациях придётся задействовать дополнительные аргументы, например:

> ../images/program/prog1_tabmob.png
> ../images/program/prog1_tabmob@2x.png
> ../images/program/prog1_desktop.png
> ../images/program/prog1_desktop@2x.png

будет обеспечено командой
`@include bgimg('../images/program/prog1', 'png', 'tabmob', 'tabmob');`

при чём лишние медиа-запросы не создадутся (хотя тут я не всё предусмотрел, но на всё не хватит времени).